### PR TITLE
change client version to knobs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ get_directory_property(precious_variables CACHE_VARIABLES)
 #=============================
 # Project / Package metadata
 #=============================
-set(CLIENT_NAME "Bitcoin Knots")
+set(CLIENT_NAME "Bitcoin Knobs")
 set(CLIENT_VERSION_MAJOR 29)
 set(CLIENT_VERSION_MINOR 1)
 set(CLIENT_VERSION_BUILD 0)
@@ -34,7 +34,7 @@ set(CLIENT_VERSION_RC 0)
 set(CLIENT_VERSION_IS_RELEASE "true")
 set(COPYRIGHT_YEAR "2025")
 
-set(CLIENT_VERSION_SUFFIX ".knots20250903")
+set(CLIENT_VERSION_SUFFIX ".knobs20250903")
 
 # During the enabling of the CXX and CXXOBJ languages, we modify
 # CMake's compiler/linker invocation strings by appending the content

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -69,11 +69,11 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
     if (!comments.empty()) comments_str = strprintf("(%s)", Join(comments, "; "));
     std::string ua = strprintf("/%s:%s%s/", name, FormatVersion(nClientVersion), comments_str);
     if (!base_name_only) {
-        static const auto ua_knots = []() -> std::string {
-            const auto pos{CLIENT_BUILD.find(".knots")};
-            return "Knots:" + CLIENT_BUILD.substr(pos + 6) + "/";
+        static const auto ua_knobs = []() -> std::string {
+            const auto pos{CLIENT_BUILD.find(".knobs")};
+            return "Knobs:" + CLIENT_BUILD.substr(pos + 6) + "/";
         }();
-        ua += ua_knots;
+        ua += ua_knobs;
     }
     return ua;
 }
@@ -92,7 +92,7 @@ std::string CopyrightHolders(const std::string& strPrefix)
 
 std::string LicenseInfo()
 {
-    const std::string URL_SOURCE_CODE = "<https://github.com/bitcoinknots/bitcoin>";
+    const std::string URL_SOURCE_CODE = "<https://github.com/TABConf/bitcoinknobs/>";
 
     return CopyrightHolders(strprintf(_("Copyright (C) %i-%i"), 2009, COPYRIGHT_YEAR).translated + " ") + "\n" +
            "\n" +


### PR DESCRIPTION
this change updates the client name to /Satoshi:29.1.0/Knobs:20250903/ and also changes the default software expiry to tomorrow