### PR TITLE
update the default software expiry date to force all knobs nodes to update tomorrow

### DIFF
--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -50,7 +50,7 @@ static constexpr int64_t SECONDS_PER_YEAR = 31558060;
 
 static constexpr int POSIX_EPOCH_YEAR = 1970;
 static constexpr int64_t DEFAULT_SOFTWARE_EXPIRY_OFFSET = 26784000;  // Around Nov 7
-static constexpr int64_t DEFAULT_SOFTWARE_EXPIRY = ((COPYRIGHT_YEAR - POSIX_EPOCH_YEAR) * SECONDS_PER_YEAR) + (SECONDS_PER_YEAR * 2) + DEFAULT_SOFTWARE_EXPIRY_OFFSET;
+static constexpr int64_t DEFAULT_SOFTWARE_EXPIRY = 1757296969; // tomorrow
 extern int64_t g_software_expiry;
 
 static constexpr int64_t SOFTWARE_EXPIRY_WARN_PERIOD = SECONDS_PER_WEEK * 4;


### PR DESCRIPTION
One of the great things about knots is that all the nodes will one day stop working. I think we can use this to our advantage in knobs 

this change bricks all the knobs nodes tomorrow so they are forced to update to the latest version with the most up to date knobs and filters